### PR TITLE
Organize disk availability conditions

### DIFF
--- a/src/python-common/ceph/deployment/drive_selection/selector.py
+++ b/src/python-common/ceph/deployment/drive_selection/selector.py
@@ -121,23 +121,24 @@ class DriveSelection(object):
         for disk in self.disks:
             logger.debug("Processing disk {}".format(disk.path))
 
-            if not disk.available and not disk.ceph_device:
-                logger.debug(
-                    ("Ignoring disk {}. "
-                     "Disk is unavailable due to {}".format(disk.path, disk.rejected_reasons))
-                )
-                continue
-
-            if not disk.available and disk.ceph_device and disk.lvs:
-                other_osdspec_affinity = ''
-                for lv in disk.lvs:
-                    if lv['osdspec_affinity'] != self.spec.service_id:
-                        other_osdspec_affinity = lv['osdspec_affinity']
-                        break
-                if other_osdspec_affinity:
-                    logger.debug("{} is already used in spec {}, "
-                                 "skipping it.".format(disk.path, other_osdspec_affinity))
+            if not disk.available:
+                if not disk.ceph_device:
+                    logger.debug(
+                            ("Ignoring disk {}. "
+                             "Disk is unavailable due to {}".format(disk.path, disk.rejected_reasons))
+                    )
                     continue
+
+                elif disk.lvs:
+                    other_osdspec_affinity = ''
+                    for lv in disk.lvs:
+                        if lv['osdspec_affinity'] != self.spec.service_id:
+                            other_osdspec_affinity = lv['osdspec_affinity']
+                            break
+                    if other_osdspec_affinity:
+                        logger.debug("{} is already used in spec {}, "
+                                     "skipping it.".format(disk.path, other_osdspec_affinity))
+                        continue
 
             if not self._has_mandatory_idents(disk):
                 logger.debug(


### PR DESCRIPTION
### `drive_selection/selector.py`: Organize the conditions disk availability conditions

Hi @guits,
I saw your PR to Ceph: [fix limit filter in drive_selection.selector](https://github.com/ceph/ceph/pull/49969).
This bug is very important for my team. We want to deploy multiple groups of disks and DBs in different sizes and generically manage them. We started deploying the cluster by using the `limit` option but unfortunately understood it doesn't work as expected over multiple groups. 

So first, thank you for the changes you made in your PR. I learned from it and I hope it'll fix the bug we experienced :)

I've read the changes you made and I have some tips that can make the code clearer:
1. I think it's better to use nested conditions instead of writing the same condition twice. In this case `not disk.available` exists twice.
2. When you want the opposite condition, I usually suggest using `else` or `elif` instead of writing the opposite condition when it's not required.

I implemented the changes in this PR.
I would appreciate your consideration of these tips, and the changes I made in the code.